### PR TITLE
Fixed issue loading DBMySQLi.php in propel in sf1.3 and sf1.4

### DIFF
--- a/src/Hostnet/HnDependencyInjectionPlugin/HnDatabaseConfigHandler.php
+++ b/src/Hostnet/HnDependencyInjectionPlugin/HnDatabaseConfigHandler.php
@@ -179,7 +179,7 @@ class HnDatabaseConfigHandler
     private function getPropelDriverName(Driver $driver)
     {
         $lookup_table = array(
-            'pdo_mysql' => 'mysqli',
+            'pdo_mysql' => 'mysql',
             'pdo_pgsql' => 'pgsql',
             'pdo_sqlite' => 'sqlite'
         );


### PR DESCRIPTION
Somewhere after Symfony1.1, they removed DBMySQLi.php from the propel adapters. To fix the class/file not found issues, I have reverted it back to mysql as driver. A proper fix might be required. 

```
FatalErrorException: Compile Error: require(): Failed opening required 'propel/adapter/DBMySQLi.php' 
```
