### PR TITLE
added php 8 to ci build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php-versions }}
     steps:
       -   uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/symfony": "^4.4||^5.0",
         "doctrine/doctrine-bundle": ">=1.7.0",
         "doctrine/orm": ">=2.6",
-        "symfony/symfony1": ">=1.1.26"
+        "symfony/symfony1": "~1.1.27"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.5.6",


### PR DESCRIPTION
Locked symfony/symfony1 to 1.1 branch, which is the only updated and used branch and php 8 compatible.